### PR TITLE
FIX: Adapt to NLog 2.0 API changes

### DIFF
--- a/src/Autofac.Extras.NLog.Tests/Autofac.Extras.NLog.Tests.csproj
+++ b/src/Autofac.Extras.NLog.Tests/Autofac.Extras.NLog.Tests.csproj
@@ -42,9 +42,9 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1312.1622\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=1.0.0.505, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.1.0.0.505\lib\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>

--- a/src/Autofac.Extras.NLog.Tests/packages.config
+++ b/src/Autofac.Extras.NLog.Tests/packages.config
@@ -3,6 +3,6 @@
   <package id="Autofac" version="2.2.4.900" targetFramework="net45" />
   <package id="AutoFixture" version="3.16.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
-  <package id="NLog" version="1.0.0.505" targetFramework="net45" />
+  <package id="NLog" version="3.2.0.0" targetFramework="net451" allowedVersions="2.0.0" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/src/Autofac.Extras.NLog/Autofac.Extras.NLog.csproj
+++ b/src/Autofac.Extras.NLog/Autofac.Extras.NLog.csproj
@@ -39,9 +39,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.2.2.4.900\lib\NET40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="NLog, Version=1.0.0.505, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.1.0.0.505\lib\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.3.2.0.0\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Autofac.Extras.NLog/Autofac.Extras.NLog.nuspec
+++ b/src/Autofac.Extras.NLog/Autofac.Extras.NLog.nuspec
@@ -12,7 +12,7 @@
 		<tags>NLog Autofac Logger ILogger log logging</tags>
 		<dependencies>
 			<dependency id="Autofac" version="2.2.4.900" />
-			<dependency id="NLog" version="1.0.0.505" />
+			<dependency id="NLog" version="2.0" />
 		</dependencies>
 	</metadata>
 	<files>

--- a/src/Autofac.Extras.NLog/ILogger.cs
+++ b/src/Autofac.Extras.NLog/ILogger.cs
@@ -14,7 +14,7 @@ namespace Autofac.Extras.NLog
         /// <summary>
         /// Occurs when logger configuration changes.
         /// </summary>
-        event LoggerReconfiguredDelegate LoggerReconfigured;
+        event EventHandler<EventArgs> LoggerReconfigured;
 
         /// <summary>
         /// Gets the name of the logger.

--- a/src/Autofac.Extras.NLog/LoggerAdapter.cs
+++ b/src/Autofac.Extras.NLog/LoggerAdapter.cs
@@ -24,7 +24,7 @@ namespace Autofac.Extras.NLog
         /// <summary>
         /// Occurs when logger configuration changes.
         /// </summary>
-        public event LoggerReconfiguredDelegate LoggerReconfigured
+        public event EventHandler<EventArgs> LoggerReconfigured
         {
             add { _logger.LoggerReconfigured += value; }
             remove { _logger.LoggerReconfigured -= value; }
@@ -74,7 +74,7 @@ namespace Autofac.Extras.NLog
 
         public void LogException(LogLevel level, string message, Exception exception)
         {
-            _logger.LogException(level, message, exception);
+            _logger.Log(level, message, exception);
         }
 
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, params object[] args)

--- a/src/Autofac.Extras.NLog/packages.config
+++ b/src/Autofac.Extras.NLog/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="2.2.4.900" targetFramework="net45" />
-  <package id="NLog" version="1.0.0.505" targetFramework="net45" />
+  <package id="NLog" version="3.2.0.0" targetFramework="net40" allowedVersions="2.0.0" />
 </packages>


### PR DESCRIPTION
The NLog dependency in .nuspec should be changed as well:

`<dependency id="NLog" version="2.0"  />`