### PR TITLE
Updated references to NLog 4.4.1 and Autofac 2.2.4.900

### DIFF
--- a/src/Autofac.Extras.NLog.Tests/Autofac.Extras.NLog.Tests.csproj
+++ b/src/Autofac.Extras.NLog.Tests/Autofac.Extras.NLog.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Extras.NLog.Tests</RootNamespace>
     <AssemblyName>Autofac.Extras.NLog.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -35,9 +35,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=2.2.4.900, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.2.2.4.900\lib\NET40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Common.Testing.NUnit, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Common.Testing.NUnit.1.0.0\lib\net45\Common.Testing.NUnit.dll</HintPath>
@@ -55,9 +55,9 @@
       <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.3.2.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.4.1\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/src/Autofac.Extras.NLog.Tests/NLogModuleTests.cs
+++ b/src/Autofac.Extras.NLog.Tests/NLogModuleTests.cs
@@ -23,7 +23,7 @@ namespace Autofac.Extras.NLog.Tests
         [Test]
         public void Inject_Logger_To_Constructor_Test()
         {
-            ISampleClass sampleClass = _container.Resolve<ISampleClass>("constructor");
+            ISampleClass sampleClass = _container.ResolveNamed<ISampleClass>("constructor");
 
             Assert.NotNull(sampleClass.GetLogger());
         }
@@ -31,7 +31,7 @@ namespace Autofac.Extras.NLog.Tests
         [Test]
         public void Inject_Logger_To_Property_Test()
         {
-            ISampleClass sampleClass = _container.Resolve<ISampleClass>("property");
+            ISampleClass sampleClass = _container.ResolveNamed<ISampleClass>("property");
 
             Assert.NotNull(sampleClass.GetLogger());
         }

--- a/src/Autofac.Extras.NLog.Tests/SimpleNLogModuleTests.cs
+++ b/src/Autofac.Extras.NLog.Tests/SimpleNLogModuleTests.cs
@@ -1,4 +1,6 @@
-﻿using Common.Testing.NUnit;
+﻿using Autofac.Core;
+using Autofac.Core.Activators.Reflection;
+using Common.Testing.NUnit;
 using NUnit.Framework;
 
 namespace Autofac.Extras.NLog.Tests
@@ -36,15 +38,14 @@ namespace Autofac.Extras.NLog.Tests
         [Test]
         public void Inject_Logger_To_Constructor_Test()
         {
-            ISampleClass sampleClass = _container.Resolve<ISampleClass>("constructor");
-
+            ISampleClass sampleClass = _container.ResolveNamed<ISampleClass>("constructor");
             Assert.NotNull(sampleClass.GetLogger());
         }
 
         [Test]
         public void Inject_Logger_To_Property_Test()
         {
-            ISampleClass sampleClass = _container.Resolve<ISampleClass>("property");
+            ISampleClass sampleClass = _container.ResolveNamed<ISampleClass>("property");
 
             Assert.NotNull(sampleClass.GetLogger());
         }
@@ -52,7 +53,7 @@ namespace Autofac.Extras.NLog.Tests
         [Test]
         public void Resolve_Logger_From_LifetimeScope_Test()
         {
-            ISampleClass sampleClass = _container.Resolve<ISampleClass>("serviceLocator");
+            ISampleClass sampleClass = _container.ResolveNamed<ISampleClass>("serviceLocator");
 
             Assert.NotNull(sampleClass.GetLogger());
         }

--- a/src/Autofac.Extras.NLog.Tests/packages.config
+++ b/src/Autofac.Extras.NLog.Tests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="2.2.4.900" targetFramework="net45" userInstalled="true" />
+  <package id="Autofac" version="4.3.0" targetFramework="net451" userInstalled="true" />
   <package id="AutoFixture" version="3.24.3" targetFramework="net451" userInstalled="true" />
   <package id="Common.Testing.NUnit" version="1.0.0" targetFramework="net451" userInstalled="true" />
   <package id="FluentAssertions" version="3.3.0" targetFramework="net451" userInstalled="true" />
   <package id="Moq" version="4.2.1502.0911" targetFramework="net451" userInstalled="true" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net451" allowedVersions="[2.0.0, )" userInstalled="true" />
+  <package id="NLog" version="4.4.1" targetFramework="net451" allowedVersions="[2.0.0, )" userInstalled="true" />
   <package id="NUnit" version="2.6.4" targetFramework="net451" userInstalled="true" />
 </packages>

--- a/src/Autofac.Extras.NLog/Autofac.Extras.NLog.csproj
+++ b/src/Autofac.Extras.NLog/Autofac.Extras.NLog.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Autofac.Extras.NLog</RootNamespace>
     <AssemblyName>Autofac.Extras.NLog</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -35,13 +35,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac, Version=2.2.4.900, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Autofac.2.2.4.900\lib\NET40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=4.3.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <HintPath>..\packages\Autofac.4.3.0\lib\net45\Autofac.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NLog, Version=3.2.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NLog.3.2.0.0\lib\net40\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.4.1\lib\net45\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Autofac.Extras.NLog/LoggerAdapter.cs
+++ b/src/Autofac.Extras.NLog/LoggerAdapter.cs
@@ -74,7 +74,7 @@ namespace Autofac.Extras.NLog
 
         public void LogException(LogLevel level, string message, Exception exception)
         {
-            _logger.Log(level, message, exception);
+            _logger.Log(level, exception, message);
         }
 
         public void Log(LogLevel level, IFormatProvider formatProvider, string message, params object[] args)
@@ -133,7 +133,7 @@ namespace Autofac.Extras.NLog
         }
         public void Trace(string message, Exception exception)
         {
-            _logger.Trace(message, exception);
+            _logger.Trace(exception, message);
         }
 
         public void Trace(IFormatProvider formatProvider, string message, params object[] args)
@@ -193,7 +193,7 @@ namespace Autofac.Extras.NLog
 
         public void Debug(string message, Exception exception)
         {
-            _logger.Debug(message, exception);
+            _logger.Debug(exception, message);
         }
 
         public void Debug(IFormatProvider formatProvider, string message, params object[] args)
@@ -253,7 +253,7 @@ namespace Autofac.Extras.NLog
 
         public void Info(string message, Exception exception)
         {
-            _logger.Info(message, exception);
+            _logger.Info(exception, message);
         }
 
         public void Info(IFormatProvider formatProvider, string message, params object[] args)
@@ -313,7 +313,7 @@ namespace Autofac.Extras.NLog
 
         public void Warn(string message, Exception exception)
         {
-            _logger.Warn(message, exception);
+            _logger.Warn(exception, message);
         }
 
         public void Warn(IFormatProvider formatProvider, string message, params object[] args)
@@ -373,7 +373,7 @@ namespace Autofac.Extras.NLog
 
         public void Error(string message, Exception exception)
         {
-            _logger.Error(message, exception);
+            _logger.Error(exception, message);
         }
 
         public void Error(IFormatProvider formatProvider, string message, params object[] args)
@@ -433,7 +433,7 @@ namespace Autofac.Extras.NLog
 
         public void Fatal(string message, Exception exception)
         {
-            _logger.Fatal(message, exception);
+            _logger.Fatal(exception,message);
         }
 
         public void Fatal(IFormatProvider formatProvider, string message, params object[] args)

--- a/src/Autofac.Extras.NLog/NullLogger.cs
+++ b/src/Autofac.Extras.NLog/NullLogger.cs
@@ -470,5 +470,10 @@ namespace Autofac.Extras.NLog
         {
             
         }
+
+        protected virtual void OnLoggerReconfigured()
+        {
+            LoggerReconfigured?.Invoke(this, EventArgs.Empty);
+        }
     }
 }

--- a/src/Autofac.Extras.NLog/NullLogger.cs
+++ b/src/Autofac.Extras.NLog/NullLogger.cs
@@ -470,10 +470,6 @@ namespace Autofac.Extras.NLog
         {
             
         }
-
-        protected virtual void OnLoggerReconfigured()
-        {
-            LoggerReconfigured?.Invoke(this, EventArgs.Empty);
-        }
+       
     }
 }

--- a/src/Autofac.Extras.NLog/packages.config
+++ b/src/Autofac.Extras.NLog/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="2.2.4.900" targetFramework="net45" />
-  <package id="NLog" version="3.2.0.0" targetFramework="net40" allowedVersions="2.0.0" />
+  <package id="Autofac" version="4.3.0" targetFramework="net452" />
+  <package id="NLog" version="4.4.1" targetFramework="net452" allowedVersions="2.0.0" />
 </packages>


### PR DESCRIPTION
Retarget .Net 4.5.2
Modify tests so they pass using ResolveNamed.
Updating deprecated methods